### PR TITLE
Should be chown. Fixed.

### DIFF
--- a/hive-validation/0-run-as-hdfs.sh
+++ b/hive-validation/0-run-as-hdfs.sh
@@ -7,4 +7,4 @@ if [ "${USER}" != "hdfs" ]; then
 fi
 
 hdfs dfs -test -d /apps/hive/shared/validation/lib && echo "Shared Lib directory exists" || hdfs dfs -mkdir -p /apps/hive/shared/validation/lib
-hdfs dfs -chmod -R hive /apps/hive/shared
+hdfs dfs -chown -R hive /apps/hive/shared


### PR DESCRIPTION
Little fix where chown should have been instead of chmod. Otherwise you get this:

```
$ ./0-run-as-hdfs.sh
-chmod: chmod : mode 'hive' does not match the expected pattern.
Usage: hadoop fs [generic options] -chmod [-R] <MODE[,MODE]... | OCTALMODE> PATH...
```
